### PR TITLE
 Update to explicitly use @grant GM_addStyle 

### DIFF
--- a/mfcassist.tamper.js
+++ b/mfcassist.tamper.js
@@ -4,6 +4,7 @@
 // @description	Assists MFC models/users track countdowns and some other basic stats regarding tips received.
 // @include	http://www.myfreecams.com/*
 // @match http://www.myfreecams.com/*
+// @grant GM_addStyle
 
 // ==/UserScript==
 

--- a/mfcassist.user.js
+++ b/mfcassist.user.js
@@ -4,6 +4,7 @@
 // @description	Assists MFC models/users track countdowns and some other basic stats regarding tips received.
 // @include	http://www.myfreecams.com/*
 // @match http://www.myfreecams.com/*
+// @grant GM_addStyle
 
 // ==/UserScript==
 


### PR DESCRIPTION
Simply added:
  //   @grant GM_addStyle 
to the metadata block to support more recent versions of Greasemonkey.

Tested and working now in:
Firefox 39.0 with Greasemonkey 3.2 and in 
Chrome Version 43.0.2357.134 m with Tampermonkey 3.11
