### PR TITLE
Fixed broken MFC URLs

### DIFF
--- a/mfcassist.tamper.js
+++ b/mfcassist.tamper.js
@@ -18,7 +18,7 @@ if (navigator.userAgent.match(/chrome/i)) {
 }
 
 //for some reason @match doesn't appear to work properly in Chrome, so check it here
-if (0 === window.location.href.indexOf('http://www.myfreecams.com/mfc2/static/player.html')) {
+if (0 === window.location.href.indexOf('http://www.myfreecams.com/_html/player.html')) {
 
     var maStyles = [
         '    #ma-alert ',

--- a/mfcassist.user.js
+++ b/mfcassist.user.js
@@ -18,7 +18,7 @@ if (navigator.userAgent.match(/chrome/i)) {
 }
 
 //for some reason @match doesn't appear to work properly in Chrome, so check it here
-if (0 === window.location.href.indexOf('http://www.myfreecams.com/mfc2/static/player.html')) {
+if (0 === window.location.href.indexOf('http://www.myfreecams.com/_html/player.html')) {
 
     var maStyles = [
         '    #ma-alert ',


### PR DESCRIPTION
Seems as if MFC moved the `player.html` from `/mfc2/static/` to `/_html/`.

This just fixes that.
